### PR TITLE
fix: default sg rules, eip association, IMDV2 metadata, timestamp tag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,10 @@ resource "aws_internet_gateway" "gw" {
 
 resource "aws_default_security_group" "default" {
   vpc_id = aws_vpc.main.id
+}
+
+resource "aws_security_group" "ec2" {
+  vpc_id = aws_vpc.main.id
 
   ingress {
     description = "SSH into VPC"
@@ -51,6 +55,6 @@ resource "aws_default_security_group" "default" {
   }
 
   tags = {
-    Name = "${var.name}_default_sg"
+    Name = "${var.name}_ec2_sg"
   }
 }


### PR DESCRIPTION
Closes #7, Closes #6, Closes #5, Closes #3

by:

- Creating a new security group with the existing rules
- Removing rules on the default security group 
- Creating an elastic IP and associating it with the instance
- Turning off the automatic IP the instance gets
- Adding a tag that includes the creation timestamp