### PR TITLE
fix: use a string for http_tokens value

### DIFF
--- a/instance.tf
+++ b/instance.tf
@@ -6,7 +6,7 @@ resource "aws_instance" "dev_work" {
   associate_public_ip_address = false
 
   metadata_options {
-    http_tokens = required
+    http_tokens = "required"
   }
 
   network_interface {


### PR DESCRIPTION
Needs to be a string so it doesn't fail
